### PR TITLE
Update api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ Create a new Snippet on this dpaste installation. It returns the full URL that s
 **Example request:**
 
 ```bash
-$ curl -X POST -F "format=url" -F "content=ABC" https:/dpaste.org/api/
+$ curl -X POST -F "format=url" -F "content=ABC" https://dpaste.org/api/
 
 Host: dpaste.org
 User-Agent: curl/7.82.0


### PR DESCRIPTION
API endpoint was wrong it was "https:/dpaste.org/api/" and not "https://dpaste.org/api/"

as you can see, a / was missing, which could trough an invalid url error